### PR TITLE
[DDIDO-287] Adds smtp and queue_mail deps, ensure Reply-To header is correct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # baywatch
 Configuration for integration with Bay hosting platform
+
+## Features
+
+- Ensures dependencies required for the bay hosting platform are installed.
+- Allows configuring the default `Reply-To` email address via `SMTP_REPLYTO` environment variable.

--- a/baywatch.info.yml
+++ b/baywatch.info.yml
@@ -9,5 +9,7 @@ dependencies:
   - purge:purge_processor_lateruntime
   - purge:purge_queuer_coretags
   - purge:purge_ui
+  - queue_mail:queue_mail
   - redis:redis
   - section_purger
+  - smtp:smtp

--- a/baywatch.module
+++ b/baywatch.module
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ *
+ * Procedural hooks for baywatch module.
+ */
+
+/**
+ * Implements hook_mail_alter().
+ */
+function baywatch_mail_alter(&$message) {
+  // Ensures that the Reply-To header points to a no-reply address if it is
+  // using the default value. This is to ensure the SES verified address
+  // doesn't get spammed. The second check ensures that modules which change
+  // the reply-to (such as webform) still function correctly.
+  //
+  // The SMTP_REPLYTO environment variable is set in lagoon.
+  $reply_to = getenv("SMTP_REPLYTO") ?: '';
+  if ($reply_to && ($message['from'] == $message['reply-to'])) {
+    $message['reply-to'] = $reply_to;
+  }
+}

--- a/baywatch.module
+++ b/baywatch.module
@@ -19,5 +19,6 @@ function baywatch_mail_alter(&$message) {
   $reply_to = getenv("SMTP_REPLYTO") ?: '';
   if ($reply_to && ($message['from'] == $message['reply-to'])) {
     $message['reply-to'] = $reply_to;
+    $message['headers']['Reply-to'] = $reply_to;
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
         "drupal/purge": "^3.0@beta",
         "drupal/purge_queuer_url": "^1.0@RC",
         "drupal/redis": "^1.0@RC",
-        "drupal/section_purger": "0.2.3"
+        "drupal/section_purger": "0.2.3",
+        "drupal/smtp": "^1.0@RC",
+        "drupal/queue_mail": "^1"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
## Problem

Drupal allows configuring the `From` email header (via the `system.site.mail` config). For AWS SES this needs to be an address we have verified (in most cases it will be `admin@vic.gov.au`).

We don't want people replying to these lifecycle emails, thus the `Reply-To` address should be `no-reply@vic.gov.au`.

Unfortunately there is no way to configure a default value for `Reply-To` - drupal will use the system.site.mail value unless the module sending the email specifies a different reply address. An example of this is webform when the notification email uses an email submitted in the form as the reply address.

## Solution

The `From` header is simple - we use a config override to set `system.site.mail` with an environment variable (this would be done in the settings file included in bay images - `/bay/settings.php`).

The `Reply-To` address is solved with the `hook_mail_alter()` implementation in this pull request.

The `queue_mail` module has been added as a dependency as it helps ensure email deliverability, and is therefore better grouped with infrastructure-related modules.

The `smtp` module allows Drupal to connect directly to the SES SMTP endpoint, rather than going through MTAs. A benefit of this is when SES rejects an email for whatever reason, Drupal will know. Combined with queue_mail this should ensure no emails are lost to the ether.