### PR TITLE
[DDIDO-287] Added update hook to ensure queue_mail processes all mail.

### DIFF
--- a/baywatch.install
+++ b/baywatch.install
@@ -53,6 +53,6 @@ function baywatch_update_8001() {
 function baywatch_update_8002() {
   $config_factory = \Drupal::configFactory();
   $config = $config_factory->getEditable('queue_mail.settings');
-  $config->set('queue_mail_keys', '');
+  $config->set('queue_mail_keys', '*');
   $config->save();
 }

--- a/baywatch.install
+++ b/baywatch.install
@@ -14,6 +14,9 @@ function baywatch_install() {
 
   // This Will import password policy during first install of the module.
   baywatch_import_sdpa_password_policy();
+
+  // Ensure queue_mail is configured to handle all mail.
+  baywatch_update_8002();
 }
 
 /**
@@ -41,4 +44,15 @@ function baywatch_import_sdpa_password_policy() {
  */
 function baywatch_update_8001() {
   baywatch_import_sdpa_password_policy();
+}
+
+/**
+ * Strip the previously configured "queue_mail_keys" as now all mail should go
+ * through the queue.
+ */
+function baywatch_update_8002() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('queue_mail.settings');
+  $config->set('queue_mail_keys', '');
+  $config->save();
 }


### PR DESCRIPTION
queue_mail is currently configured to only send tide_workflow_notification emails. This update hook removes that filter so that all mail will use the queue.