### PR TITLE
[DDIDO-256] Added update hook to drop obsolote tables with old_ prefix.

### DIFF
--- a/baywatch.install
+++ b/baywatch.install
@@ -64,3 +64,27 @@ function baywatch_update_8002() {
   $config->set('queue_mail_keys', '*');
   $config->save();
 }
+
+/**
+ * [DDIDO-256] Clean up orphaned tables from failed core update.
+ */
+function baywatch_update_8003() {
+  $tables = [];
+  $r = \Drupal::database()->query("SHOW TABLES LIKE 'old_%'");
+  $rows = $r->fetchCol();
+  if (!empty($rows)) {
+    foreach ($rows as $row) {
+      $tables[] = $row;
+    }
+  }
+
+  foreach ($tables as $table) {
+    try {
+      \Drupal::messenger()->addMessage("Dropping obsolete table ${table}");
+      \Drupal::database()->query(sprintf("DROP TABLE %s;", $table));
+    } catch (\Exception $e) {
+      \Drupal::messenger()->addMessage("Error when dropping table ${table}");
+      \Drupal::logger('baywatch')->error($e->getMessage());
+    }
+  }
+}


### PR DESCRIPTION
One of the core update hooks "backed up" tables be prefixing them with `old_`. There is also [code which is supposed to delete these tables](https://git.drupalcode.org/project/drupal/-/blob/8.6.x/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorageSchemaConverter.php#L224), but it was not executed. It is reasonable to assume this deployment failed during this core update, resulting in many tables with the `old_` prefix persisting in the database until now.

This has been seen in several projects including content-vic and content-premier.