### PR TITLE
[SDPSUP-2884] : Remove Purge Late Runtime module

### DIFF
--- a/baywatch.info.yml
+++ b/baywatch.info.yml
@@ -6,7 +6,6 @@ core: 8.x
 dependencies:
   - purge:purge
   - purge:purge_processor_cron
-  - purge:purge_processor_lateruntime
   - purge:purge_queuer_coretags
   - purge:purge_ui
   - password_policy:password_policy

--- a/baywatch.install
+++ b/baywatch.install
@@ -289,3 +289,10 @@ function baywatch_update_8008(&$sandbox) {
     $sandbox['#finished'] = $sandbox['#finished'] > 1 ? 1 : $sandbox['#finished'];
   }
 }
+
+/**
+ * Uninstall the late runtime processor.
+ */
+function baywatch_update_8009() {
+  \Drupal::service('module_installer')->uninstall(['purge_processor_lateruntime']);
+}


### PR DESCRIPTION
Changed:
1) Remove purge_processor_lateruntime as a dependency.
2) Add update hook to uninstall the module.

Rationale:
We already process the purge queue via a cronjob. Having the late runtime processor enabled just slows Drupal down (as it tries to process the queue at the end of every request).