### PR TITLE
[SRM-35][SRM-36] Added fix to sitename check logic.

### DIFF
--- a/baywatch.install
+++ b/baywatch.install
@@ -287,14 +287,8 @@ function baywatch_update_8008(&$sandbox) {
  * Except Vicpol and SSP.
  */
 function baywatch_update_8009() {
-  $module_handler = \Drupal::moduleHandler();
-  $authenticated_module_exist = $module_handler->moduleExists('tide_authenticated_content');
-  // Load the site name out of configuration.
-  $config = \Drupal::config('system.site');
-  $site_name = $config->get('name');
-  if (($site_name !== 'Victoria Police' || $site_name !== 'Shared Service Provider Content Repository') && $authenticated_module_exist) {
-    \Drupal::service('module_installer')->uninstall(['tide_authenticated_content']);
-  }
+  $baywatch = new BaywatchOperation();
+  $baywatch->remove_authenticated_content();
 }
 
 /**

--- a/src/BaywatchOperation.php
+++ b/src/BaywatchOperation.php
@@ -213,7 +213,7 @@ class BaywatchOperation
     // Load the site name out of configuration.
     $config = \Drupal::config('system.site');
     $site_name = $config->get('name');
-    if (($site_name !== 'Victoria Police' || $site_name !== 'Shared Service Provider Content Repository') && $authenticated_module_exist) {
+    if ($site_name !== 'Victoria Police' && $site_name !== 'Shared Service Provider Content Repository' && $authenticated_module_exist) {
       \Drupal::service('module_installer')->uninstall(['tide_authenticated_content']);
     }
   }


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SRM-35
https://digital-engagement.atlassian.net/browse/SRM-36

### issue
Removes the authenticated content for vicpol and ssp.

### Changes
Update sitename logic check to make both the condition true when checking the site name instead of or.