### PR TITLE
Add tests for existence of Site and Primary Site fields

### DIFF
--- a/tests/behat/features/site-fields.feature
+++ b/tests/behat/features/site-fields.feature
@@ -1,0 +1,52 @@
+@install
+Feature: Site and primary site fields exist.
+
+  Fresh install of tide profile has the site and primary site fields available
+
+  @api
+  Scenario: Event has primary and site fields
+    Given I am logged in as a user with the "editor" role
+    When I visit "node/add/event/"
+    And save screenshot
+    Then I see field "edit-field-node-site"
+    And I see field "edit-field-node-primary-site"
+
+  @api
+  Scenario: Landing page has primary and site fields
+    Given I am logged in as a user with the "editor" role
+    When I visit "node/add/landing_page/"
+    And save screenshot
+    Then I see field "edit-field-node-site"
+    And I see field "edit-field-node-primary-site"
+
+  @api
+  Scenario: News has primary and site fields
+    Given I am logged in as a user with the "editor" role
+    When I visit "node/add/news/"
+    And save screenshot
+    Then I see field "edit-field-node-site"
+    And I see field "edit-field-node-primary-site"
+
+  @api
+  Scenario: Page has primary and site fields
+    Given I am logged in as a user with the "editor" role
+    When I visit "node/add/page/"
+    And save screenshot
+    Then I see field "edit-field-node-site"
+    And I see field "edit-field-node-primary-site"
+
+  @api
+  Scenario: Publication has primary and site fields
+    Given I am logged in as a user with the "editor" role
+    When I visit "node/add/publication/"
+    And save screenshot
+    Then I see field "edit-field-node-site"
+    And I see field "edit-field-node-primary-site"
+
+  @api
+  Scenario: Publication page has primary and site fields
+    Given I am logged in as a user with the "editor" role
+    When I visit "node/add/publication_page/"
+    And save screenshot
+    Then I see field "edit-field-node-site"
+    And I see field "edit-field-node-primary-site"


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/DDS-245

### Changed

1. Add a test to check that site and primary site fields are available on the content add form.
This is to test the changes in https://github.com/dpc-sdp/tide_site/pull/90 (and ongoing)

### Screenshots

Output from [build](https://app.circleci.com/pipelines/github/dpc-sdp/reference-sdp-vic-gov-au/227/workflows/0af68935-f7ef-4834-9c68-35af62b61e1e/jobs/339) without fix:

![image](https://user-images.githubusercontent.com/4596219/127133511-4e483e2f-8d05-45cb-bf1d-6add6284e41d.png)

Output from [build](https://app.circleci.com/pipelines/github/dpc-sdp/reference-sdp-vic-gov-au/228/workflows/da24a548-1c91-4bf9-a5f2-b5368bef9cf4/jobs/340) with fix from tide_site:

![image](https://user-images.githubusercontent.com/4596219/127133602-48b1dc9f-c500-4ae1-b3b6-89e19fce1f6c.png)

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
