### PR TITLE
[SRM-123] : Add shield as a dependency

### DIFF
--- a/baywatch.info.yml
+++ b/baywatch.info.yml
@@ -4,6 +4,7 @@ type: module
 package: Other
 core: 8.x
 dependencies:
+  - shield:shield
   - purge:purge
   - purge:purge_processor_cron
   - purge:purge_queuer_coretags


### PR DESCRIPTION
JIRA issue: https://digital-engagement.atlassian.net/browse/SRM-123

Changed:
1) Add shield as a dependency

Baywatch has an implicit dependency on the shield module during install - https://github.com/dpc-sdp/baywatch/blob/1c511eea0df7f196827bd4df995f23d036f8820e/src/BaywatchOperation.php#L64

This install hook will fail to write the necessary config for tide_oauth if Baywatch is installed before shield.