### PR TITLE
[SW-1185] keeps purge at 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "drush/drush": "^10.3",
-        "drupal/purge": "^3.0@beta",
+        "drupal/purge": "3.0",
         "drupal/purge_queuer_url": "^1.0@RC",
         "drupal/redis": "^1.0@RC",
         "drupal/section_purge": "2.3-rc2",


### PR DESCRIPTION
### Issue
https://www.drupal.org/project/purge/releases/8.x-3.1
The purge just released its newset version that breaks our site.

In Drupal 9.3.x, Drupalcore removed the usage of `isMasterRequest` function, and uses [`isMainRequest`](https://git.drupalcode.org/project/purge/-/blob/8.x-3.1/src/EventSubscriber/CacheableResponseSubscriber.php#L49) instead, which is inline with the change of symfony. but purge module replaced `isMasterRequest`  by isMainRequest  in `3.1` which causes fatal error in php requests. 

### Solution
next month(probably this month) we are going move drupal 9, so, the solution just keeps `purge` at 3.0 for now.