### PR TITLE
[SRM-329] Fixes an issue where var is undefined

### DIFF
--- a/baywatch.install
+++ b/baywatch.install
@@ -369,20 +369,23 @@ function baywatch_update_8017() {
 function baywatch_update_8018() {
   // config_split files
   $configs = [
-      'config_split.config_split.ci',
-      'config_split.config_split.dev',
-      'config_split.config_split.local',
+    'config_split.config_split.ci',
+    'config_split.config_split.dev',
+    'config_split.config_split.local',
   ];
   /*
    * IF elasticsearch_connector.cluster.elasticsearch_bay in greylist
    * THEN remove it from the list
    */
   foreach ($configs as $config) {
-      $active_config = \Drupal::configFactory()->getEditable($config);
-      $es_connector = 'elasticsearch_connector.cluster.elasticsearch_bay';
-      if (in_array($es_connector, $active_graylist) && ($key = array_search($es_connector, $active_graylist)) !== false) {
-          unset($active_graylist[$key]);
+    $active_config = \Drupal::configFactory()->getEditable($config);
+    $es_connector = 'elasticsearch_connector.cluster.elasticsearch_bay';
+    $active_graylist = $active_config->get('graylist');
+    if (!empty($active_graylist)) {
+      if (in_array($es_connector, $active_graylist) && ($key = array_search($es_connector, $active_graylist)) !== FALSE) {
+        unset($active_graylist[$key]);
       }
       $active_config->set('graylist', $active_graylist)->save();
+    }
   }
 }


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SRM-329

### Issue 
```bash
[warning] in_array() expects parameter 2 to be array, null given baywatch.install:383
[warning] in_array() expects parameter 2 to be array, null given baywatch.install:383
[warning] in_array() expects parameter 2 to be array, null given baywatch.install:383
```

```php
 [error]  TypeError: Argument 2 passed to Drupal\config_split\Plugin\ConfigFilter\SplitFilter::inFilterList() must be of the type array, null given, called in /app/docroot/modules/contrib/config_split/src/Plugin/ConfigFilter/SplitFilter.php on line 379 in Drupal\config_split\Plugin\ConfigFilter\SplitFilter::inFilterList() (line 402 of /app/docroot/modules/contrib/config_split/src/Plugin/ConfigFilter/SplitFilter.php) #0 /app/docroot/modules/contrib/config_split/src/Plugin/ConfigFilter/SplitFilter.php(379): Drupal\config_split\Plugin\ConfigFilter\SplitFilter::inFilterList('admin_toolbar.s...', NULL)

```
The issue cased by an undefined var `$active_graylist` in https://github.com/dpc-sdp/baywatch/blob/master/baywatch.install#L369 hook.

### Fix
define variable `$active_graylist`.