### PR TITLE
Adds default CSP settings. 

### DIFF
--- a/baywatch.info.yml
+++ b/baywatch.info.yml
@@ -25,8 +25,9 @@ dependencies:
   - jwt:jwt
 config_devel:
   optional:
-  - password_policy.password_policy.password_policy_sdpa
-  - key.key.authenticated_content
-  - config_split.config_split.ci
-  - config_split.config_split.dev
-  - config_split.config_split.local
+    - password_policy.password_policy.password_policy_sdpa
+    - key.key.authenticated_content
+    - config_split.config_split.ci
+    - config_split.config_split.dev
+    - config_split.config_split.local
+    - seckit.settings

--- a/baywatch.install
+++ b/baywatch.install
@@ -36,6 +36,7 @@ function baywatch_install() {
   $baywatch->import_default_section_config();
   $baywatch->enable_tide_block_inactive_users();
   $baywatch->enable_tide_spell_checker();
+  $baywatch->import_default_csp_config();
 }
 
 /**
@@ -387,5 +388,18 @@ function baywatch_update_8018() {
       }
       $active_config->set('graylist', $active_graylist)->save();
     }
+  }
+}
+
+/**
+ * Check if csp enabled or not.
+ */
+function baywatch_update_8019() {
+  $seckit_config = Drupal::configFactory()->getEditable('seckit.settings');
+  $condition_1 = $seckit_config->get('seckit_xss.csp.checkbox');
+  $condition_2 = $seckit_config->get('seckit_xss.csp.script-src');
+  $condition_3 = $seckit_config->get('seckit_xss.csp.connect-src');
+  if (empty($condition_1) || empty($condition_2) || empty($condition_3)) {
+    throw new \RuntimeException('seckit.settings has incorrect settings.');
   }
 }

--- a/baywatch.install
+++ b/baywatch.install
@@ -444,16 +444,3 @@ function baywatch_update_8022() {
   $baywatch = new BaywatchOperation();
   $baywatch->enable_tide_content_collection();
 }
-
-/**
- * Check if csp enabled or not.
- */
-function baywatch_update_8023() {
-  $seckit_config = Drupal::configFactory()->getEditable('seckit.settings');
-  $condition_1 = $seckit_config->get('seckit_xss.csp.checkbox');
-  $condition_2 = $seckit_config->get('seckit_xss.csp.script-src');
-  $condition_3 = $seckit_config->get('seckit_xss.csp.connect-src');
-  if (empty($condition_1) || empty($condition_2) || empty($condition_3)) {
-    throw new \RuntimeException('seckit.settings has incorrect settings.');
-  }
-}

--- a/config/optional/seckit.settings.yml
+++ b/config/optional/seckit.settings.yml
@@ -1,0 +1,54 @@
+seckit_xss:
+  csp:
+    checkbox: true
+    report-only: false
+    default-src: '''self'''
+    script-src: '''self'' ''unsafe-inline'' svc.webspellchecker.net'
+    object-src: ''
+    img-src: '''self'' data: reference.vic.gov.au *.reference.vic.gov.au content.reference.vic.gov.au *.content.reference.vic.gov.au *.amazee.io tracking.monsido.com *.google-analytics.com *.g.doubleclick.net www.google.com *.google.com *.google.com.au api.mapbox.com svc.webspellchecker.net'
+    media-src: ''
+    frame-src: '''self'' batchgeo.com *.vimeo.com *.youtube.com livestream.com'
+    child-src: ''
+    font-src: '''self'' svc.webspellchecker.net'
+    connect-src: '''self'' svc.webspellchecker.net'
+    report-uri: /report-csp-violation
+    policy-uri: ''
+    vendor-prefix:
+      x: false
+      webkit: false
+    upgrade-req: false
+    style-src: '''self''  ''unsafe-inline'' svc.webspellchecker.net'
+    frame-ancestors: ''
+  x_xss:
+    seckit_x_xss_option_disable: Disabled
+    seckit_x_xss_option_0: '0'
+    seckit_x_xss_option_1: 1;
+    seckit_x_xss_option_1_block: '1; mode=block'
+    select: 0
+seckit_csrf:
+  origin: false
+  origin_whitelist: 'https://freetafevicmap.com'
+seckit_clickjacking:
+  js_css_noscript: false
+  noscript_message: 'Sorry, you need to enable JavaScript to visit this website.'
+  x_frame: '1'
+  x_frame_allow_from: ''
+seckit_ssl:
+  hsts: true
+  hsts_subdomains: true
+  hsts_max_age: 1000
+  hsts_preload: false
+seckit_various:
+  from_origin: true
+  from_origin_destination: same
+  disable_autocomplete: false
+  referrer_policy: true
+  referrer_policy_policy: strict-origin-when-cross-origin
+seckit_ct:
+  expect_ct: false
+  max_age: null
+  report_uri: ''
+  enforce: false
+seckit_fp:
+  feature_policy: false
+  feature_policy_policy: ''

--- a/config/optional/seckit.settings.yml
+++ b/config/optional/seckit.settings.yml
@@ -5,7 +5,7 @@ seckit_xss:
     default-src: '''self'''
     script-src: '''self'' ''unsafe-inline'' svc.webspellchecker.net'
     object-src: ''
-    img-src: '''self'' data: reference.vic.gov.au *.reference.vic.gov.au content.reference.vic.gov.au *.content.reference.vic.gov.au *.amazee.io tracking.monsido.com *.google-analytics.com *.g.doubleclick.net www.google.com *.google.com *.google.com.au api.mapbox.com svc.webspellchecker.net'
+    img-src: '''self'' data: *.vic.gov.au *.amazee.io tracking.monsido.com *.google-analytics.com *.g.doubleclick.net www.google.com *.google.com *.google.com.au api.mapbox.com svc.webspellchecker.net'
     media-src: ''
     frame-src: '''self'' batchgeo.com *.vimeo.com *.youtube.com livestream.com'
     child-src: ''

--- a/src/BaywatchOperation.php
+++ b/src/BaywatchOperation.php
@@ -307,4 +307,12 @@ class BaywatchOperation
     $this->baywatch_install_module('tide_spell_checker');
   }
 
+  public function import_default_csp_config() {
+    module_load_include('inc', 'tide_core', 'includes/helpers');
+    $config_location = [drupal_get_path('module', 'baywatch') . '/config/optional'];
+    $read = _tide_read_config('seckit.settings', $config_location, FALSE);
+    $config_storage = \Drupal::service('config.storage');
+    $config_storage->write('seckit.settings', $read);
+  }
+
 }

--- a/src/BaywatchOperation.php
+++ b/src/BaywatchOperation.php
@@ -388,6 +388,7 @@ class BaywatchOperation
     $index->save();
   }
 
+  // Import default SDP specific settings.
   public function import_default_csp_config() {
     module_load_include('inc', 'tide_core', 'includes/helpers');
     $config_location = [drupal_get_path('module', 'baywatch') . '/config/optional'];


### PR DESCRIPTION
### Motivation
sometimes our CMS may encounter JS issues, mostly because of a lack of CSP settings.

### Issues
- During 1.39.0 and 1.39.1 updates, we have manually found and fixed some issues with CSP, for example, MHCC and VLA etc...
- This patch is for the reference site and checking whether the CSP has correct settings in other projects.
- each site may have unique CSP settings, so if it finds, the dev should fix it in the ansible or another way in the next release.

### Changes
1. install the setting on a new site.
2. roughly check if the site has the correct settings.

----
_Open for discussion; if you have a better and easy way to add default CSP, please leave some comments._