### PR TITLE
Updated hook to separate updates for the cc tasks.

### DIFF
--- a/baywatch.install
+++ b/baywatch.install
@@ -103,7 +103,7 @@ function baywatch_import_sdpa_password_policy() {
  */
 function baywatch_update_dependencies() {
   $dependencies = [];
-  $dependencies['baywatch'][8022] = ['tide_content_collection' => 8001];
+  $dependencies['baywatch'][8023] = ['tide_content_collection' => 8001];
 
   return $dependencies;
 }
@@ -442,4 +442,12 @@ function baywatch_update_8021() {
 function baywatch_update_8022() {
   $baywatch = new BaywatchOperation();
   $baywatch->enable_tide_content_collection();
+}
+
+/**
+ * Add content collection to landing page.
+ */
+function baywatch_update_8023() {
+  $baywatch = new BaywatchOperation();
+  $baywatch->add_cc_to_landing_page();
 }

--- a/src/BaywatchOperation.php
+++ b/src/BaywatchOperation.php
@@ -326,6 +326,13 @@ class BaywatchOperation
   public function enable_tide_content_collection() {
     // Enable tide_content_collection module.
     $this->baywatch_install_module('tide_content_collection');
+    // It will run for first time install of tide_content_collection.
+    $this->add_cc_to_landing_page();
+  }
+
+  public function add_cc_to_landing_page() {
+    // Enable tide_content_collection module.
+    $this->baywatch_install_module('tide_content_collection');
     $field = FieldConfig::loadByName('node', 'landing_page', 'field_landing_page_component');
     // Add both content collection custom and enhanced to landing page.
     if ($field) {

--- a/src/BaywatchOperation.php
+++ b/src/BaywatchOperation.php
@@ -354,8 +354,10 @@ class BaywatchOperation
     $config_factory = \Drupal::configFactory();
     $config = $config_factory->getEditable('core.entity_form_display.paragraph.content_collection_enhanced.default');
     $allowed_content_types = ['landing_page', 'news'];
-    $config->set('content.field_content_collection_config.settings.content.internal.contentTypes.allowed_values', $allowed_content_types);
-    $config->save();
+    if ($config) {
+      $config->set('content.field_content_collection_config.settings.content.internal.contentTypes.allowed_values', $allowed_content_types);
+      $config->save();
+    }
 
     // Add fields to search API.
     $index = \Drupal::entityTypeManager()


### PR DESCRIPTION
### JIRA
https://digital-engagement.atlassian.net/browse/SRM-428

### Issue 
So the update hook was dependant on the update hook of tide_conent_collection. But the projects that didn't have the content collection module enabled, it couldn't resolved the dependency and ended up content collection module not getting installed for the projects that doesn't have the module.

### Changes
Added a new hook which will install the tide_content_collection module first and then will call another function which will add it to landing page. For the project that already has it, will need the new cc component in the landing page.