### PR TITLE
Added check on dependencies.

### DIFF
--- a/baywatch.install
+++ b/baywatch.install
@@ -103,7 +103,9 @@ function baywatch_import_sdpa_password_policy() {
  */
 function baywatch_update_dependencies() {
   $dependencies = [];
-  $dependencies['baywatch'][8023] = ['tide_content_collection' => 8001];
+  if (\Drupal::service('module_handler')->moduleExists('tide_content_collection')) {
+    $dependencies['baywatch'][8022] = ['tide_content_collection' => 8001];
+  }
 
   return $dependencies;
 }
@@ -442,12 +444,4 @@ function baywatch_update_8021() {
 function baywatch_update_8022() {
   $baywatch = new BaywatchOperation();
   $baywatch->enable_tide_content_collection();
-}
-
-/**
- * Add content collection to landing page.
- */
-function baywatch_update_8023() {
-  $baywatch = new BaywatchOperation();
-  $baywatch->add_cc_to_landing_page();
 }

--- a/src/BaywatchOperation.php
+++ b/src/BaywatchOperation.php
@@ -326,13 +326,6 @@ class BaywatchOperation
   public function enable_tide_content_collection() {
     // Enable tide_content_collection module.
     $this->baywatch_install_module('tide_content_collection');
-    // It will run for first time install of tide_content_collection.
-    $this->add_cc_to_landing_page();
-  }
-
-  public function add_cc_to_landing_page() {
-    // Enable tide_content_collection module.
-    $this->baywatch_install_module('tide_content_collection');
     $field = FieldConfig::loadByName('node', 'landing_page', 'field_landing_page_component');
     // Add both content collection custom and enhanced to landing page.
     if ($field) {


### PR DESCRIPTION
### JIRA
https://digital-engagement.atlassian.net/browse/SRM-428

### Issue 
So the update hook was dependant on the update hook of tide_conent_collection. But the projects that didn't have the content collection module enabled, it couldn't resolved the dependency and ended up content collection module not getting installed for the projects that doesn't have the module.

### Changes
Added check if tide_content_collection module exists before adding the hook dependency.