### PR TITLE
SDPA-6277: update baywatch.install to uninstall admin_toolbar_search

### DIFF
--- a/baywatch.install
+++ b/baywatch.install
@@ -423,3 +423,14 @@ function baywatch_update_8021() {
   $baywatch = new BaywatchOperation();
   $baywatch->enable_autologout();
 }
+
+/**
+ * Uninstall admin_toolbar_search module
+ */
+function baywatch_update_8022() {
+  $module_installer = \Drupal::service('module_installer');
+  $module_handler = \Drupal::moduleHandler();
+  if ($module_handler->moduleExists('admin_toolbar_search')) {
+    $module_installer->uninstall(['admin_toolbar_search']);
+  }
+}


### PR DESCRIPTION
**Jira**
https://digital-engagement.atlassian.net/browse/SDPA-6277

**Changes**
1. Updated baywatch.install to check if admin_toolbar_search is installed and uninstall if it is