### PR TITLE
Remove field_tools module from local split

### DIFF
--- a/config/optional/config_split.config_split.local.yml
+++ b/config/optional/config_split.config_split.local.yml
@@ -9,7 +9,6 @@ module:
   config_devel: 0
   dblog: 0
   devel_generate: 0
-  field_tools: 0
   views_ui: 0
 theme: { }
 blacklist: { }


### PR DESCRIPTION
## Motivation

Working on ESV.CONTENT.VIC.GOV.AU and this drupal/field_tools module is not installed into new projects, so breaks config import locally. Removing it from optional config. 

The field_tools module is not available in new projects.

## Change

- Remove field_tools module from local split
