### PR TITLE
[DDS-72] External service monitoring

### DIFF
--- a/baywatch.install
+++ b/baywatch.install
@@ -586,6 +586,8 @@ function baywatch_update_8031() {
 function baywatch_update_8032() {
   $baywatch = new BaywatchOperation();
   $baywatch->enable_monitoring();
+  // Remove all default sensors installed by the monitoring module as we don't want them.
   $baywatch->reset_sensor_config();
+  // Install our custom sensors.
   $baywatch->ensure_sensor_configuration();
 }

--- a/baywatch.install
+++ b/baywatch.install
@@ -579,3 +579,12 @@ function baywatch_update_8031() {
   $baywatch = new BaywatchOperation();
   $baywatch->enable_bay_platform_dependencies();
 }
+
+/**
+ * Enable and configure the monitoring module and sensors.
+ */
+function baywatch_update_8032() {
+  $baywatch = new BaywatchOperation();
+  $baywatch->enable_monitoring();
+  $baywatch->ensure_sensor_configuration();
+}

--- a/baywatch.install
+++ b/baywatch.install
@@ -586,5 +586,6 @@ function baywatch_update_8031() {
 function baywatch_update_8032() {
   $baywatch = new BaywatchOperation();
   $baywatch->enable_monitoring();
+  $baywatch->reset_sensor_config();
   $baywatch->ensure_sensor_configuration();
 }

--- a/baywatch.install
+++ b/baywatch.install
@@ -44,6 +44,9 @@ function baywatch_install() {
   $baywatch->enable_tide_logs();
   $baywatch->enable_tide_site_alert();
   $baywatch->enable_bay_platform_dependencies();
+  $baywatch->enable_monitoring();
+  $baywatch->reset_sensor_config();
+  $baywatch->ensure_sensor_configuration();
 }
 
 /**

--- a/baywatch.routing.yml
+++ b/baywatch.routing.yml
@@ -1,0 +1,7 @@
+baywatch.endpoint:
+  path: '/healthz'
+  defaults:
+    _controller: '\Drupal\baywatch\Controller\HealthzController::json'
+  methods: [GET]
+  requirements:
+    _baywatch_healthz_access: 'TRUE'

--- a/baywatch.services.yml
+++ b/baywatch.services.yml
@@ -1,0 +1,10 @@
+services:
+  cache_context.healthz_header_token:
+    class: Drupal\baywatch\Cache\Context\HealthzHeaderTokenCacheContext
+    arguments: ['@request_stack']
+    tags:
+      - { name: cache.context }
+  baywatch.access.healthz:
+    class: \Drupal\baywatch\Access\HealthzAccessCheck
+    tags:
+      - { name: access_check, applies_to: _baywatch_healthz_access }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "drupal/queue_mail": "^1",
     "drupal/jwt": "^1.0",
     "drupal/config_split": "^1.4",
-    "dpc-sdp/bay_platform_dependencies": "^1.0"
+    "dpc-sdp/bay_platform_dependencies": "^1.0",
+    "drupal/monitoring": "^1.13"
   },
   "repositories": {
     "drupal": {

--- a/src/Access/HealthzAccessCheck.php
+++ b/src/Access/HealthzAccessCheck.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\baywatch\Access;
+
+use Drupal\Core\Site\Settings;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Check if a token is present in GET args.
+ */
+class HealthzAccessCheck implements AccessInterface {
+
+    /**
+     * Name of a GET param to get the key.
+     */
+    protected const TOKEN_HEADER_NAME = 'Healthz-Token';
+
+    /**
+     * Determine access for the healthz endpoint.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *   The incoming HTTP request object.
+     *
+     * @return \Drupal\Core\Access\AccessResult
+     *   An access result.
+     */
+    public function access(Request $request): AccessResult {
+      $expected_key = Settings::get('baywatch.healthz_key');
+      if (empty($expected_key)) {
+        throw new \Exception('baywatch.healthz_key is not set!');
+      }
+      $user_key = $request->headers->get(static::TOKEN_HEADER_NAME);
+      // Substring caps the value length.
+      return AccessResult::allowedIf((is_string($user_key) && substr($user_key, 0, 32) == $expected_key))
+        ->addCacheContexts(['healthz_header_token']);
+    }
+}

--- a/src/BaywatchOperation.php
+++ b/src/BaywatchOperation.php
@@ -7,8 +7,40 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\user\Entity\Role;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\search_api\Item\Field;
+use Drupal\monitoring\Entity\SensorConfig;
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\Entity\EntityStorageException;
 
 class BaywatchOperation {
+
+
+  public function ensure_sensor_configuration() {
+    if (\Drupal::service('module_handler')->moduleExists('section_purger')) {
+      $section_sensor = SensorConfig::create(array(
+        'id' => 'section_purger',
+        'label' => 'Section Purger',
+        'description' => 'Connectivity Status of the Section Purger',
+        'plugin_id' => 'tide_external_service',
+        'value_label' => 'Section Purger',
+        'category' => 'Baywatch',
+        'status' => TRUE,
+        'caching_time' => 300,
+        'settings' => array(
+          'check_type' => 'section'
+        ),
+        'thresholds' => array(
+          'type' => 'exceeds',
+          'warning' => 0,
+          'critical' => 0,
+        ),
+      ));
+      try {
+        $section_sensor->save();
+      } catch (EntityStorageException $e) {
+        \Drupal::messenger()->addMessage("section_purger sensor already configured.");
+      }
+    }
+  }
 
   /**
    * Helper to install a module.
@@ -417,6 +449,13 @@ class BaywatchOperation {
     // Enable bay_platform_dependencies module.
     $this->baywatch_install_module('bay_platform_dependencies');
   }
+
+  public function enable_monitoring() {
+      // Enable monitoring module.
+      $this->baywatch_install_module('monitoring');
+  }
+
+
 
 }
 

--- a/src/BaywatchOperation.php
+++ b/src/BaywatchOperation.php
@@ -421,8 +421,8 @@ class BaywatchOperation {
   }
 
   public function enable_monitoring() {
-      // Enable monitoring module.
-      $this->baywatch_install_module('monitoring');
+    // Enable monitoring module.
+    $this->baywatch_install_module('monitoring');
   }
 
   public function reset_sensor_config() {
@@ -456,7 +456,9 @@ class BaywatchOperation {
       ),
     ));
   }
+
   public function ensure_sensor_configuration() {
+    // Install the appropriate set of custom sensors based on enabled modules.
     if (\Drupal::service('module_handler')->moduleExists('section_purger')) {
       $sensor = $this->create_sensor(
         'section_purger',

--- a/src/Cache/Context/HealthzHeaderTokenCacheContext.php
+++ b/src/Cache/Context/HealthzHeaderTokenCacheContext.php
@@ -1,0 +1,19 @@
+<?php
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Cache\Context\RequestStackCacheContextBase;
+
+class HealthzHeaderTokenCacheContext extends RequestStackCacheContextBase {
+    /**
+     * Name of a GET param to get the key.
+     */
+    protected const TOKEN_HEADER_NAME = 'Healthz-Token';
+
+    public function getContext() {
+      return $this->requestStack->getCurrentRequest()->headers->get(static::TOKEN_HEADER_NAME);
+    }
+
+    public function getCacheableMetadata() {
+      return new CacheableMetadata();
+    }
+}

--- a/src/Controller/HealthzController.php
+++ b/src/Controller/HealthzController.php
@@ -17,11 +17,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class HealthzController extends ControllerBase {
 
     /**
-     * Minimum period to wait between re-checking sensor status.
-     */
-    protected const MINIMUM_CHECK_INTERVAL = 30;
-
-    /**
      * The sensor runner.
      *
      * @var \Drupal\monitoring\SensorRunner
@@ -78,11 +73,6 @@ class HealthzController extends ControllerBase {
       } else {
         $response = new CacheableJsonResponse(['message' => 'All sensors OK!']);
       }
-
-      // 30 second break between sensors runs at a minimum.
-      $cache_metadata = new CacheableMetadata();
-      $cache_metadata->setCacheMaxAge(static::MINIMUM_CHECK_INTERVAL);
-      $response->addCacheableDependency($cache_metadata);
 
       return $response;
     }

--- a/src/Controller/HealthzController.php
+++ b/src/Controller/HealthzController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\baywatch\Controller;
+
+use Drupal\Core\Cache\CacheableJsonResponse;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\monitoring\Entity\SensorResultDataInterface;
+use Drupal\monitoring\Result\SensorResult;
+use Drupal\monitoring\SensorRunner;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * Monitoring controller.
+ */
+class HealthzController extends ControllerBase {
+
+    /**
+     * Name of a GET param to get the key.
+     */
+    protected const MINIMUM_CHECK_INTERVAL = 30;
+
+    /**
+     * The sensor runner.
+     *
+     * @var \Drupal\monitoring\SensorRunner
+     */
+    protected $sensorRunner;
+
+    /**
+     * Constructs a \Drupal\monitoring\Form\SensorDetailForm object.
+     *
+     * @param \Drupal\monitoring\SensorRunner $sensor_runner
+     *   The factory for configuration objects.
+     */
+    public function __construct(SensorRunner $sensor_runner) {
+      $this->sensorRunner = $sensor_runner;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function create(ContainerInterface $container) {
+      return new static(
+        $container->get('monitoring.sensor_runner')
+      );
+    }
+
+    /**
+     * API endpoint to get health for the site.
+     *
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     *   A JSON response.
+     */
+    public function json(): JsonResponse {
+      // Results may be cached from sensor runner.
+      $results = $this->sensorRunner->runSensors();
+
+      $resultFailures = array_filter($results, function (SensorResult $result): bool {
+        return $result->getStatus() === SensorResultDataInterface::STATUS_CRITICAL;
+      });
+
+      $response = [];
+      if (count($resultFailures) > 0) {
+        $response = [
+          'failed_sensor_count' => count($resultFailures),
+          'failed_sensors' => [],
+        ];
+
+        foreach ($resultFailures as $resultFailure) {
+          array_push($response['failed_sensors'], [
+            'sensor_name' => $resultFailure->getSensorId(),
+            'sensor_message' => $resultFailure->getMessage()
+          ]);
+        }
+        $response = new CacheableJsonResponse($response, 500);
+      } else {
+        $response = new CacheableJsonResponse(['message' => 'All sensors OK!']);
+      }
+
+      // 30 second break between sensors runs at a minimum.
+      $cache_metadata = new CacheableMetadata();
+      $cache_metadata->setCacheMaxAge(static::MINIMUM_CHECK_INTERVAL);
+      $response->addCacheableDependency($cache_metadata);
+
+      return $response;
+    }
+}

--- a/src/Controller/HealthzController.php
+++ b/src/Controller/HealthzController.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class HealthzController extends ControllerBase {
 
     /**
-     * Name of a GET param to get the key.
+     * Minimum period to wait between re-checking sensor status.
      */
     protected const MINIMUM_CHECK_INTERVAL = 30;
 

--- a/src/Plugin/monitoring/SensorPlugin/TideExternalServiceSensorPlugin.php
+++ b/src/Plugin/monitoring/SensorPlugin/TideExternalServiceSensorPlugin.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Drupal\baywatch\Plugin\monitoring\SensorPlugin;
+
+use Drupal\monitoring\Result\SensorResultInterface;
+use Drupal\monitoring\SensorPlugin\SensorPluginBase;
+use Drupal\monitoring\SensorPlugin\SensorPluginInterface;
+use Drupal\section_purger\Entity\SectionPurgerSettings;
+use GuzzleHttp\ClientInterface;
+use Drupal\monitoring\Entity\SensorConfig;
+use Drupal\key\KeyRepositoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Custom sensor plugin.
+ *
+ * @SensorPlugin(
+ *   id = "tide_external_service",
+ *   label = @Translation("My Custom Sensor"),
+ *   description = @Translation("Description of your custom sensor."),
+ *   provider = "baywatch",
+ * )
+ */
+class TideExternalServiceSensorPlugin extends SensorPluginBase implements SensorPluginInterface {
+    /**
+     * The client interface.
+     *
+     * @var \GuzzleHttp\ClientInterface
+     */
+    protected $client;
+
+    /**
+     * The key repository.
+     *
+     * @var \Drupal\key\KeyRepository
+     */
+    protected $keyRepository;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(SensorConfig $sensor_config, $plugin_id, $plugin_definition, ClientInterface $http_client, KeyRepositoryInterface $key_repository) {
+      parent::__construct($sensor_config, $plugin_id, $plugin_definition);
+      $this->client = $http_client;
+      $this->keyRepository = $key_repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function create(ContainerInterface $container, SensorConfig $sensor_config, $plugin_id, $plugin_definition) {
+      return new static(
+        $sensor_config,
+        $plugin_id,
+        $plugin_definition,
+        $container->get('http_client'),
+        $container->get('key.repository')
+      );
+    }
+
+    public function runSensor(SensorResultInterface $result)
+    {
+        $check_type = $this->sensorConfig->getSetting('check_type');
+        switch ($check_type) {
+          case 'section':
+            $this->checkSection($result);
+            break;
+          case 'mailgun':
+            break;
+        }
+    }
+
+
+    protected function checkSection(SensorResultInterface &$result) {
+      $purgers = SectionPurgerSettings::loadMultiple();
+      $purger = reset($purgers);
+
+      if (empty($purger)) {
+        $result->setStatus(SensorResultInterface::STATUS_CRITICAL);
+        $result->setMessage('Section purger is not configured.');
+        return;
+      }
+
+      $uri = sprintf(
+        '%s://%s:%s/api/v1/account/%s/application/%s/environment/%s',
+        $purger->scheme,
+        $purger->hostname,
+        $purger->port,
+        $purger->account,
+        $purger->application,
+        $purger->environmentname
+      );
+
+      $opt = array(
+        'auth' => [$purger->username, $this->keyRepository->getKey($purger->password)->getKeyValue()],
+        'connect_timeout' => $purger->connect_timeout,
+        'timeout' => $purger->timeout,
+      );
+
+      // Sensor interface catches raised exceptions - Guzzle will throw
+      // an exception when HTTP >= 400.
+      $this->client->get($uri, $opt);
+
+      $result->setValue(0);
+      $result->addStatusMessage('Section OK!');
+    }
+
+    protected function checkMailgun(SensorResultInterface &$result) {
+      $result->setValue(1);
+      $result->addStatusMessage('Not implemented!');
+    }
+
+    protected function checkTwitter(SensorResultInterface &$result) {
+      $result->setValue(1);
+      $result->addStatusMessage('Not implemented!');
+    }
+
+    protected function checkVuelio(SensorResultInterface &$result) {
+      $result->setValue(1);
+      $result->addStatusMessage('Not implemented!');
+    }
+}

--- a/src/Plugin/monitoring/SensorPlugin/TideExternalServiceSensorPlugin.php
+++ b/src/Plugin/monitoring/SensorPlugin/TideExternalServiceSensorPlugin.php
@@ -27,11 +27,8 @@ class TideExternalServiceSensorPlugin extends SensorPluginBase implements Sensor
     /**
      * {@inheritdoc}
      */
-    public function __construct(SensorConfig $sensor_config, $plugin_id, $plugin_definition, ClientInterface $http_client, KeyRepositoryInterface $key_repository, ConfigFactoryInterface $config_factory) {
+    public function __construct(SensorConfig $sensor_config, $plugin_id, $plugin_definition) {
       parent::__construct($sensor_config, $plugin_id, $plugin_definition);
-      $this->client = $http_client;
-      $this->keyRepository = $key_repository;
-      $this->config = $config_factory->get(Constants::SETTINGS);
     }
 
     /**
@@ -41,10 +38,7 @@ class TideExternalServiceSensorPlugin extends SensorPluginBase implements Sensor
       return new static(
         $sensor_config,
         $plugin_id,
-        $plugin_definition,
-        $container->get('http_client'),
-        $container->get('key.repository'),
-        $container->get('config.factory')
+        $plugin_definition
       );
     }
 

--- a/src/Plugin/monitoring/SensorPlugin/TideExternalServiceSensorPlugin.php
+++ b/src/Plugin/monitoring/SensorPlugin/TideExternalServiceSensorPlugin.php
@@ -17,8 +17,8 @@ use Drupal\baywatch\Plugin\monitoring\Support\TideExternalServiceSensorVuelioSup
  *
  * @SensorPlugin(
  *   id = "tide_external_service",
- *   label = @Translation("My Custom Sensor"),
- *   description = @Translation("Description of your custom sensor."),
+ *   label = @Translation("Tide External Service Sensor"),
+ *   description = @Translation("Checks connectivity to external services used by Tide sites."),
  *   provider = "baywatch",
  * )
  */
@@ -42,8 +42,7 @@ class TideExternalServiceSensorPlugin extends SensorPluginBase implements Sensor
       );
     }
 
-    public function runSensor(SensorResultInterface $result)
-    {
+    public function runSensor(SensorResultInterface $result) {
         $check_type = $this->sensorConfig->getSetting('check_type');
         switch ($check_type) {
           case 'section':
@@ -63,7 +62,7 @@ class TideExternalServiceSensorPlugin extends SensorPluginBase implements Sensor
 
 
     protected function checkSection(SensorResultInterface &$result) {
-      // Just in case the required modules have become uninstalled.
+      // Check that required modules and classes still exist in case they have been inadvertently removed.
       $required_modules_classes_exist = \Drupal::moduleHandler()->moduleExists('section_purger') && \Drupal::moduleHandler()->moduleExists('key');
 
       if ($required_modules_classes_exist) {
@@ -76,7 +75,7 @@ class TideExternalServiceSensorPlugin extends SensorPluginBase implements Sensor
     }
 
     protected function checkMailgun(SensorResultInterface &$result) {
-
+      // Check that required modules and classes still exist in case they have been inadvertently removed.
       $required_modules_classes_exist = \Drupal::moduleHandler()->moduleExists('tide_mailgun') && class_exists('\Mailgun\Mailgun');
 
       if ($required_modules_classes_exist) {
@@ -90,7 +89,7 @@ class TideExternalServiceSensorPlugin extends SensorPluginBase implements Sensor
     }
 
     protected function checkTwitter(SensorResultInterface &$result) {
-
+      // Check that required modules and classes still exist in case they have been inadvertently removed.
       $required_modules_classes_exist = \Drupal::moduleHandler()->moduleExists('social_api') && \Drupal::moduleHandler()->moduleExists('social_post') && class_exists('\Abraham\TwitterOAuth\TwitterOAuth');
 
       if ($required_modules_classes_exist) {
@@ -104,7 +103,7 @@ class TideExternalServiceSensorPlugin extends SensorPluginBase implements Sensor
     }
 
     protected function checkVuelio(SensorResultInterface &$result) {
-
+      // Check that required modules and classes still exist in case they have been inadvertently removed.
       $required_modules_classes_exist = \Drupal::moduleHandler()->moduleExists('vicpol_vuelio');
 
       if ($required_modules_classes_exist) {

--- a/src/Plugin/monitoring/Support/TideExternalServiceSensorMailgunSupport.php
+++ b/src/Plugin/monitoring/Support/TideExternalServiceSensorMailgunSupport.php
@@ -8,6 +8,7 @@ use Drupal\tide_mailgun\Constants;
 use Drupal\tide_mailgun\Utils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Mailgun\Mailgun;
 
 class TideExternalServiceSensorMailgunSupport implements TideExternalServiceSupportInterface, ContainerInjectionInterface {
     /**
@@ -52,5 +53,5 @@ class TideExternalServiceSensorMailgunSupport implements TideExternalServiceSupp
       $result->setStatus('Mailgun OK!');
       $result->setValue(TRUE);
     }
-    }
+
 }

--- a/src/Plugin/monitoring/Support/TideExternalServiceSensorMailgunSupport.php
+++ b/src/Plugin/monitoring/Support/TideExternalServiceSensorMailgunSupport.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\baywatch\Plugin\monitoring\Support;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\monitoring\Result\SensorResultInterface;
+use Drupal\tide_mailgun\Constants;
+use Drupal\tide_mailgun\Utils;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+
+class TideExternalServiceSensorMailgunSupport implements TideExternalServiceSupportInterface, ContainerInjectionInterface {
+    /**
+     * The config.
+     *
+     * @var Drupal\Core\Config\ConfigFactoryInterface
+     */
+    protected $config;
+
+    public function __construct(ConfigFactoryInterface $config_factory) {
+      $this->config = $config_factory->get(Constants::SETTINGS);
+    }
+    /**
+     * @inheritDoc
+     */
+    public static function create(ContainerInterface $container) {
+      return new static(
+        $container->get('config.factory')
+      );
+    }
+
+    public function runCheck(SensorResultInterface &$result) {
+      $private_key = $this->config->get(Utils::prefix('private_key'));
+      $mg = Mailgun::create($private_key);
+
+      try {
+        $domains = $mg->domains()->index();
+      } catch (\Exception $error) {
+        $result->setStatus(SensorResultInterface::STATUS_CRITICAL);
+        $result->setMessage("Invalid credentials.");
+        $result->setValue(FALSE);
+        return;
+      }
+
+      if ($domains->getTotalCount() < 1) {
+        $result->setStatus(SensorResultInterface::STATUS_CRITICAL);
+        $result->setMessage("No available domains.");
+        $result->setValue(FALSE);
+        return;
+      }
+
+      $result->setStatus('Mailgun OK!');
+      $result->setValue(TRUE);
+    }
+    }
+}

--- a/src/Plugin/monitoring/Support/TideExternalServiceSensorSectionSupport.php
+++ b/src/Plugin/monitoring/Support/TideExternalServiceSensorSectionSupport.php
@@ -34,16 +34,14 @@ class TideExternalServiceSensorSectionSupport implements TideExternalServiceSupp
     /**
      * @inheritDoc
      */
-    public static function create(ContainerInterface $container)
-    {
+    public static function create(ContainerInterface $container) {
       return new static(
         $container->get('http_client'),
         $container->get('key.repository')
       );
     }
 
-    public function runCheck(SensorResultInterface &$result)
-    {
+    public function runCheck(SensorResultInterface &$result) {
       $purgers = SectionPurgerSettings::loadMultiple();
       $purger = reset($purgers);
 

--- a/src/Plugin/monitoring/Support/TideExternalServiceSensorSectionSupport.php
+++ b/src/Plugin/monitoring/Support/TideExternalServiceSensorSectionSupport.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\baywatch\Plugin\monitoring\Support;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\section_purger\Entity\SectionPurgerSettings;
+use GuzzleHttp\ClientInterface;
+use Drupal\key\KeyRepositoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\monitoring\Result\SensorResultInterface;
+
+class TideExternalServiceSensorSectionSupport implements TideExternalServiceSupportInterface, ContainerInjectionInterface {
+
+    /**
+     * The client interface.
+     *
+     * @var \GuzzleHttp\ClientInterface
+     */
+    protected $client;
+
+    /**
+     * The key repository.
+     *
+     * @var \Drupal\key\KeyRepository
+     */
+    protected $keyRepository;
+
+    public function __construct(ClientInterface $http_client, KeyRepositoryInterface $keyRepository) {
+      $this->client = $http_client;
+      $this->keyRepository = $keyRepository;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function create(ContainerInterface $container)
+    {
+      return new static(
+        $container->get('http_client'),
+        $container->get('key.repository')
+      );
+    }
+
+    public function runCheck(SensorResultInterface &$result)
+    {
+      $purgers = SectionPurgerSettings::loadMultiple();
+      $purger = reset($purgers);
+
+      if (empty($purger)) {
+        $result->setStatus(SensorResultInterface::STATUS_CRITICAL);
+        $result->setMessage('Section purger is not configured.');
+        return;
+      }
+
+      $uri = sprintf(
+        '%s://%s:%s/api/v1/account/%s/application/%s/environment/%s',
+        $purger->scheme,
+        $purger->hostname,
+        $purger->port,
+        $purger->account,
+        $purger->application,
+        $purger->environmentname
+      );
+
+      $opt = array(
+        'auth' => [$purger->username, $this->keyRepository->getKey($purger->password)->getKeyValue()],
+        'connect_timeout' => $purger->connect_timeout,
+        'timeout' => $purger->timeout,
+      );
+
+      // Sensor interface catches raised exceptions - Guzzle will throw
+      // an exception when HTTP >= 400.
+      $this->client->get($uri, $opt);
+
+      $result->setValue(0);
+      $result->addStatusMessage('Section OK!');
+    }
+
+
+}

--- a/src/Plugin/monitoring/Support/TideExternalServiceSensorTwitterSupport.php
+++ b/src/Plugin/monitoring/Support/TideExternalServiceSensorTwitterSupport.php
@@ -47,8 +47,7 @@ class TideExternalServiceSensorTwitterSupport implements TideExternalServiceSupp
       return $this->postManager;
     }
 
-    public function runCheck(SensorResultInterface &$result)
-    {
+    public function runCheck(SensorResultInterface &$result) {
       $config = \Drupal::config('social_post_twitter.settings');
       $consumer = $config->get('consumer_key');
       $secret = $config->get('consumer_secret');

--- a/src/Plugin/monitoring/Support/TideExternalServiceSensorTwitterSupport.php
+++ b/src/Plugin/monitoring/Support/TideExternalServiceSensorTwitterSupport.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\baywatch\Plugin\monitoring\Support;
+
+use Abraham\TwitterOAuth\TwitterOAuth;
+use Drupal\monitoring\Result\SensorResultInterface;
+
+class TideExternalServiceSensorTwitterSupport implements TideExternalServiceSupportInterface {
+
+    /**
+     * The network manager.
+     *
+     * @var \Drupal\social_api\Plugin\NetworkManager
+     */
+    protected $networkManager;
+
+    /**
+     * The social post manager.
+     *
+     * @var \Drupal\social_post\SocialPostManager
+     */
+    protected $postManager;
+
+    /**
+     * Lazy load accessor for the social network manager.
+     *
+     * @return \Drupal\social_api\Plugin\NetworkManager
+     *   The network manager.
+     */
+    protected function getNetworkManager() {
+      if (!$this->networkManager) {
+        $this->networkManager = \Drupal::service('plugin.network.manager');
+      }
+      return $this->networkManager;
+    }
+
+    /**
+     * Lazy load accessor for the auth provider.
+     *
+     * @return \Drupal\social_post\SocialPostManager
+     *   The post manager.
+     */
+    protected function getPostManager() {
+      if (!$this->postManager) {
+        $this->postManager = \Drupal::service('social_post.post_manager');
+      }
+      return $this->postManager;
+    }
+
+    public function runCheck(SensorResultInterface &$result)
+    {
+      $config = \Drupal::config('social_post_twitter.settings');
+      $consumer = $config->get('consumer_key');
+      $secret = $config->get('consumer_secret');
+
+      $connection = new TwitterOAuth($consumer, $secret);
+      $network_plugin = $this->getNetworkManager()->createInstance('social_post_twitter');
+
+      try {
+        // If we can't get a request token then the credentials are incorrect.
+        $request_token = $connection->oauth('oauth/request_token', ['oauth_callback' => $network_plugin->getOauthCallback()]);
+      } catch(\Exception $e) {
+        $result->setStatus(SensorResultInterface::STATUS_CRITICAL);
+        $result->setMessage("Invalid credentials.");
+        return;
+      }
+
+      if (empty($request_token['oauth_callback_confirmed'])) {
+        $result->setStatus(SensorResultInterface::STATUS_CRITICAL);
+        $result->setMessage("OAuth callback is not confirmed.");
+        return;
+      }
+
+      $result->setStatus(SensorResultInterface::STATUS_OK);
+    }
+}

--- a/src/Plugin/monitoring/Support/TideExternalServiceSensorVuelioSupport.php
+++ b/src/Plugin/monitoring/Support/TideExternalServiceSensorVuelioSupport.php
@@ -15,7 +15,7 @@ class TideExternalServiceSensorVuelioSupport implements TideExternalServiceSuppo
     protected $vuelio;
 
     /**
-     *
+     * @var
      */
     protected $module_handler;
 
@@ -43,7 +43,7 @@ class TideExternalServiceSensorVuelioSupport implements TideExternalServiceSuppo
       return \Drupal::service('vicpol_vuelio.vuelio_services');
     }
 
-    public function runCheck(SensorResultInterface &$result){
+    public function runCheck(SensorResultInterface &$result) {
       try {
         if (!$this->getVuelioService()->vuelioFetchXmlData(TRUE)) {
           $result->setStatus(SensorResultInterface::STATUS_CRITICAL);

--- a/src/Plugin/monitoring/Support/TideExternalServiceSensorVuelioSupport.php
+++ b/src/Plugin/monitoring/Support/TideExternalServiceSensorVuelioSupport.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\baywatch\Plugin\monitoring\Support;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\monitoring\Result\SensorResultInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+class TideExternalServiceSensorVuelioSupport implements TideExternalServiceSupportInterface, ContainerInjectionInterface {
+
+    /**
+     * @var
+     */
+    protected $vuelio;
+
+    /**
+     *
+     */
+    protected $module_handler;
+
+    public function __construct(ModuleHandlerInterface $module_handler) {
+      $this->$module_handler = $module_handler;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function create(ContainerInterface $container)
+    {
+      return new static(
+        $container->get('module_handler')
+      );
+    }
+
+    /**
+     * Lazy load the vuelio integration.
+     *
+     * @return \Drupal\vicpol_vuelio\VuelioServicesInterface
+     *   The vuelio service.
+     */
+    protected function getVuelioService() {
+      return \Drupal::service('vicpol_vuelio.vuelio_services');
+    }
+
+    public function runCheck(SensorResultInterface &$result){
+      if (!$this->getVuelioService()->vuelioFetchXmlData(TRUE)) {
+        $result->setStatus(SensorResultInterface::STATUS_WARNING);
+        $result->setMessage('Unable to connect to API.');
+      }
+
+      $result->setStatus(SensorResultInterface::STATUS_OK);
+      $result->setMessage('OK');
+    }
+}

--- a/src/Plugin/monitoring/Support/TideExternalServiceSensorVuelioSupport.php
+++ b/src/Plugin/monitoring/Support/TideExternalServiceSensorVuelioSupport.php
@@ -20,7 +20,7 @@ class TideExternalServiceSensorVuelioSupport implements TideExternalServiceSuppo
     protected $module_handler;
 
     public function __construct(ModuleHandlerInterface $module_handler) {
-      $this->$module_handler = $module_handler;
+      $this->module_handler = $module_handler;
     }
 
     /**
@@ -44,10 +44,17 @@ class TideExternalServiceSensorVuelioSupport implements TideExternalServiceSuppo
     }
 
     public function runCheck(SensorResultInterface &$result){
-      if (!$this->getVuelioService()->vuelioFetchXmlData(TRUE)) {
-        $result->setStatus(SensorResultInterface::STATUS_WARNING);
-        $result->setMessage('Unable to connect to API.');
+      try {
+        if (!$this->getVuelioService()->vuelioFetchXmlData(TRUE)) {
+          $result->setStatus(SensorResultInterface::STATUS_CRITICAL);
+          $result->setMessage('Unable to connect to API.');
+        }
+      } catch (\Error $e) {
+        $result->setStatus(SensorResultInterface::STATUS_CRITICAL);
+        $result->setMessage('Unhandled runtime error caused by vicpol_vuelio!');
+        return;
       }
+
 
       $result->setStatus(SensorResultInterface::STATUS_OK);
       $result->setMessage('OK');

--- a/src/Plugin/monitoring/Support/TideExternalServiceSupportInterface.php
+++ b/src/Plugin/monitoring/Support/TideExternalServiceSupportInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Drupal\baywatch\Plugin\monitoring\Support;
+
+use Drupal\monitoring\Result\SensorResultInterface;
+
+interface TideExternalServiceSupportInterface {
+  public function runCheck(SensorResultInterface &$result);
+}


### PR DESCRIPTION
1) Installs Drupal Monitoring framework.
2) Defines a custom sensor plugin which allows for monitoring of connectivity with Twitter, Section, and Vuelio.
3) Exposes a /healthz endpoint to allow external monitoring to health check if a Tide instance can connect to it's external services correctly.