### PR TITLE
Removed drush dependency from composer as it gets it from bay_platform_dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
   "license": "GPL-2.0-or-later",
   "require": {
     "drupal/autologout": "^1.3",
-    "drush/drush": "^11",
     "drupal/coi": "^4.0@RC",
     "drupal/purge_queuer_url": "dev-3289191-automated-drupal-10",
     "drupal/queue_mail": "^1",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "drupal/queue_mail": "^1",
     "drupal/jwt": "^1.0",
     "drupal/config_split": "^1.9",
-    "dpc-sdp/bay_platform_dependencies": "^2.0.0"
+    "dpc-sdp/bay_platform_dependencies": "^2.0.2"
   },
   "repositories": {
     "drupal": {


### PR DESCRIPTION
Removing drush from baywatch as it is already added in bay_platform_dependencies.