### PR TITLE
Added patch to fix the deprecated error message.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,15 @@
     "drupal/config_split": "^1.9",
     "dpc-sdp/bay_platform_dependencies": "^2.0.2"
   },
+  "extra": {
+    "enable-patching": true,
+    "composer-exit-on-patch-failure": true,
+    "patches": {
+      "drupal/jwt": {
+        "Deprecated function: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated - https://www.drupal.org/project/jwt/issues/3298726": "https://www.drupal.org/files/issues/2022-07-22/3298726-3.patch"
+      }
+    }
+  },
   "repositories": {
     "drupal": {
       "type": "composer",


### PR DESCRIPTION
### ISSUE 
```
Error message
Deprecated function: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in Drupal\jwt\Transcoder\JwtTranscoder->__construct() (line 113 of modules/contrib/jwt/src/Transcoder/JwtTranscoder.php).
```

### Changes 
Added jwt patch to fix it. In future, we will have to update the jwt module to 2.0 and check if that resolves the issue. But upgrading the module 2.0 might have some big change in it. That is why for now adding this patch.