### PR TITLE
Update BaywatchOperation to handle array_merge() on null.

### DIFF
--- a/src/BaywatchOperation.php
+++ b/src/BaywatchOperation.php
@@ -106,6 +106,8 @@ class BaywatchOperation {
             }
           }
         }
+        $active_graylist = $active_graylist ?? [];                                                                                                 
+        $inactive_graylist = $inactive_graylist ?? [];
         $result = array_unique(array_merge($active_graylist, $inactive_graylist));
         $active_config->set('graylist', $result)->save();
       }


### PR DESCRIPTION
### Changes
Added null check for the inputs in array_merge, if it is empty then add it as a empty array rather than empty string as array_merge expects array.