### PR TITLE
updated version bay platform dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "drupal/queue_mail": "^1",
     "drupal/jwt": "^1.0",
     "drupal/config_split": "^2.0",
-    "dpc-sdp/bay_platform_dependencies": "^2.0.2"
+    "dpc-sdp/bay_platform_dependencies": "^2.0.3"
   },
   "extra": {
     "enable-patching": true,


### PR DESCRIPTION
Section purger has been removed from bay platform dependencies and a new release version in baywatch is needed